### PR TITLE
Dev/change to winter time 2022

### DIFF
--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -425,17 +425,17 @@ radio = switch(track_sensitive=false, transitions=[
     ({1w and 20h-20h58m}, once(playlist_urmajmok)),      
     ({1w and 21h-22h58m}, once(playlist_infinite_scroll)),      
     ({1w and 15h30m-21h30m}, off_air_ambient_mix),                        #ambient: Szmuti - Infinite
-    ({2w and 1h04m-3h30m}, once(playlist_gyorsnaszad_hidja)),          #Tuesday
-    ({2w and 6h-6h28m}, once(playlist_felregombolt)),
-    ({2w and 10h-11h58m}, once(playlist_lahmaloudclouds)),
-    ({2w and 13h30m-14h58m}, once(playlist_melyvagas)),
-    ({2w and 15h-15h58m}, once(playlist_radical_happiness)),
-    ({2w and 16h-16h58m}, once(playlist_mmn_radio)),
-    ({2w and 17h-17h58m}, once(playlist_mosolyszunet)),
-    ({2w and 18h-18h58m}, once(playlist_havizaj)),
-    ({2w and 19h-19h58m}, once(playlist_turmeric_acid)),
-    ({2w and 20h-20h58m}, once(playlist_exit)),
-    ({2w and 14h-20h30m}, off_air_ambient_mix),                        #ambient: Melyvagas - Exit
+    ({2w and 2h04m-4h30m}, once(playlist_gyorsnaszad_hidja)),          #Tuesday
+    ({2w and 7h-7h28m}, once(playlist_felregombolt)),
+    ({2w and 11h-12h58m}, once(playlist_lahmaloudclouds)),
+    ({2w and 14h30m-15h58m}, once(playlist_melyvagas)),
+    ({2w and 16h-16h58m}, once(playlist_radical_happiness)),
+    ({2w and 17h-17h58m}, once(playlist_mmn_radio)),
+    ({2w and 18h-18h58m}, once(playlist_mosolyszunet)),
+    ({2w and 19h-19h58m}, once(playlist_havizaj)),
+    ({2w and 20h-20h58m}, once(playlist_turmeric_acid)),
+    ({2w and 21h-21h58m}, once(playlist_exit)),
+    ({2w and 15h-21h30m}, off_air_ambient_mix),                        #ambient: Melyvagas - Exit
     ({3w and 10h-11h58m}, once(playlist_lahmacun_presents)),           #Wednesday
     ({3w and 12h30m-12h58m}, once(playlist_tudtad)),
     ({3w and 13h-13h58m}, once(playlist_erto_hallgatas)),

--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -472,7 +472,7 @@ radio = switch(track_sensitive=false, transitions=[
     ({6w and 17h-18h58m}, once(playlist_rnr666)),
     ({6w and 19h-20h58m}, once(playlist_mood_sequence)),
     ({6w and 22h-23h28m}, once(playlist_d23)),
-    ({6w11h-6w00h}, off_air_ambient_mix),                     #ambient: Merites - Gestalt
+    ({6w11h-7w00h}, off_air_ambient_mix),                     #ambient: Merites - Gestalt
     ({7w and 9h30m-11h28m}, once(playlist_lohuma)),                    #Sunday
     ({7w and 11h30m-12h58m}, once(playlist_bambusz)),
     ({7w and 13h-15h58m}, once(playlist_donald_kacsa_klub)),

--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -447,14 +447,14 @@ radio = switch(track_sensitive=false, transitions=[
     ({3w and 21h-21h58m}, once(playlist_1800venus)),
     ({3w and 22h-22h58m}, once(playlist_linear_systems_with_gestalt)),
     ({3w and 13h15m-22h30m}, off_air_ambient_mix),                     #ambient: Tudtad - Gestalt
-    ({4w and 10h-11h58m}, once(playlist_ritka_csut)),                  #Thursday
-    ({4w and 14h-14h58m}, once(playlist_fkse)),
-    ({4w and 15h-16h58m}, once(playlist_lazy_calm_raga)),
-    ({4w and 17h-17h58m}, once(playlist_dalmata_gergo_show)),
-    ({4w and 18h-18h58m}, once(playlist_keygen)),
-    ({4w and 19h-20h58m}, once(playlist_schmerz)),
-    ({4w and 21h-22h28m}, once(playlist_gyogyfurdo)),
-    ({4w and 12h30m-21h30m}, off_air_ambient_mix),                        #ambient: Ritka csut - Gyogyf
+    ({4w and 11h-12h58m}, once(playlist_ritka_csut)),                  #Thursday
+    ({4w and 15h-15h58m}, once(playlist_fkse)),
+    ({4w and 16h-17h58m}, once(playlist_lazy_calm_raga)),
+    ({4w and 18h-18h58m}, once(playlist_dalmata_gergo_show)),
+    ({4w and 19h-19h58m}, once(playlist_keygen)),
+    ({4w and 20h-21h58m}, once(playlist_schmerz)),
+    ({4w and 22h-23h28m}, once(playlist_gyogyfurdo)),
+    ({4w and 13h30m-22h30m}, off_air_ambient_mix),                        #ambient: Ritka csut - Gyogyf
     ({5w and 10h-11h58m}, once(playlist_ritka_pentek)),                #Friday
     ({5w and 12h00m-12h28m}, once(playlist_melania)),                     
     ({5w and 12h30m-13h58m}, once(playlist_szusivacsi)),

--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -413,18 +413,18 @@ radio = switch(track_sensitive=false, transitions=[
     transition_length=60., #max duration of jingle (60s)
     [
     ({!live_enabled}, live),     #Live DJ          
-    ({1w and 8h-8h58m}, once(playlist_szedd_a_labad)),             # Monday
-    ({1w and 9h11m-10h9m}, once(playlist_transverszia)),             # orig requested time 11:11 am 12:12 pm
-    ({1w and 11h-11h58m}, once(playlist_a_who_say)),
-    ({1w and 12h-13h28m}, once(playlist_korunk)),    
-    ({1w and 14h-14h58m}, once(playlist_szmuti_csorba)),
-    ({1w and 15h-15h58m}, once(playlist_paikka)),
-    ({1w and 16h-16h58m}, once(playlist_udcsi)),
-    ({1w and 17h30m-17h58m}, once(playlist_soundscape_diaries_emcsivel)),
-    ({1w and 18h-18h58m}, once(playlist_ember_a_palyan)),
-    ({1w and 19h-19h58m}, once(playlist_urmajmok)),      
-    ({1w and 20h-21h58m}, once(playlist_infinite_scroll)),      
-    ({1w and 14h30m-20h30m}, off_air_ambient_mix),                        #ambient: Szmuti - Infinite
+    ({1w and 9h-9h58m}, once(playlist_szedd_a_labad)),             # Monday
+    ({1w and 10h11m-11h9m}, once(playlist_transverszia)),             # orig requested time 11:11 am 12:12 pm
+    ({1w and 12h-12h58m}, once(playlist_a_who_say)),
+    ({1w and 13h-14h28m}, once(playlist_korunk)),    
+    ({1w and 15h-15h58m}, once(playlist_szmuti_csorba)),
+    ({1w and 16h-16h58m}, once(playlist_paikka)),
+    ({1w and 17h-17h58m}, once(playlist_udcsi)),
+    ({1w and 18h30m-18h58m}, once(playlist_soundscape_diaries_emcsivel)),
+    ({1w and 19h-19h58m}, once(playlist_ember_a_palyan)),
+    ({1w and 20h-20h58m}, once(playlist_urmajmok)),      
+    ({1w and 21h-22h58m}, once(playlist_infinite_scroll)),      
+    ({1w and 15h30m-21h30m}, off_air_ambient_mix),                        #ambient: Szmuti - Infinite
     ({2w and 1h04m-3h30m}, once(playlist_gyorsnaszad_hidja)),          #Tuesday
     ({2w and 6h-6h28m}, once(playlist_felregombolt)),
     ({2w and 10h-11h58m}, once(playlist_lahmaloudclouds)),

--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -436,17 +436,17 @@ radio = switch(track_sensitive=false, transitions=[
     ({2w and 20h-20h58m}, once(playlist_turmeric_acid)),
     ({2w and 21h-21h58m}, once(playlist_exit)),
     ({2w and 15h-21h30m}, off_air_ambient_mix),                        #ambient: Melyvagas - Exit
-    ({3w and 10h-11h58m}, once(playlist_lahmacun_presents)),           #Wednesday
-    ({3w and 12h30m-12h58m}, once(playlist_tudtad)),
-    ({3w and 13h-13h58m}, once(playlist_erto_hallgatas)),
-    ({3w and 14h-14h58m}, once(playlist_erdenklang)),
-    ({3w and 15h-15h58m}, once(playlist_cleptorama)),
-    ({3w and 17h-17h58m}, once(playlist_rambo)),
-    ({3w and 18h-18h58m}, once(playlist_boombap)),
-    ({3w and 19h-19h58m}, once(playlist_eastern_daze)),
-    ({3w and 20h-20h58m}, once(playlist_1800venus)),
-    ({3w and 21h-21h58m}, once(playlist_linear_systems_with_gestalt)),
-    ({3w and 12h15m-21h30m}, off_air_ambient_mix),                     #ambient: Tudtad - Gestalt
+    ({3w and 11h-12h58m}, once(playlist_lahmacun_presents)),           #Wednesday
+    ({3w and 13h30m-13h58m}, once(playlist_tudtad)),
+    ({3w and 14h-14h58m}, once(playlist_erto_hallgatas)),
+    ({3w and 15h-15h58m}, once(playlist_erdenklang)),
+    ({3w and 16h-16h58m}, once(playlist_cleptorama)),
+    ({3w and 18h-18h58m}, once(playlist_rambo)),
+    ({3w and 19h-19h58m}, once(playlist_boombap)),
+    ({3w and 20h-20h58m}, once(playlist_eastern_daze)),
+    ({3w and 21h-21h58m}, once(playlist_1800venus)),
+    ({3w and 22h-22h58m}, once(playlist_linear_systems_with_gestalt)),
+    ({3w and 13h15m-22h30m}, off_air_ambient_mix),                     #ambient: Tudtad - Gestalt
     ({4w and 10h-11h58m}, once(playlist_ritka_csut)),                  #Thursday
     ({4w and 14h-14h58m}, once(playlist_fkse)),
     ({4w and 15h-16h58m}, once(playlist_lazy_calm_raga)),

--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -465,14 +465,14 @@ radio = switch(track_sensitive=false, transitions=[
     ({5w and 19h-19h58m}, once(playlist_moneyka)),
     ({5w and 20h-21h58m}, once(playlist_arcadeok_alatt)),       
     ({5w and 13h15m-22h30m}, off_air_ambient_mix),                        #ambient: Ritka pentek - Rev
-    ({6w and 9h30m-11h28m}, once(playlist_merites)),                  #Saturday
-    ({6w and 11h30m-12h28m}, once(playlist_jambikus_nesz)),     
-    ({6w and 12h30m-14h58m}, once(playlist_torso)),
-    ({6w and 15h-15h58m}, once(playlist_footwork_jimbob)),
-    ({6w and 16h-17h58m}, once(playlist_rnr666)),
-    ({6w and 18h-19h58m}, once(playlist_mood_sequence)),
-    ({6w and 21h-22h28m}, once(playlist_d23)),
-    ({6w10h-6w23h}, off_air_ambient_mix),                     #ambient: Merites - Gestalt
+    ({6w and 10h30m-12h28m}, once(playlist_merites)),                  #Saturday
+    ({6w and 12h30m-13h28m}, once(playlist_jambikus_nesz)),     
+    ({6w and 13h30m-15h58m}, once(playlist_torso)),
+    ({6w and 16h-16h58m}, once(playlist_footwork_jimbob)),
+    ({6w and 17h-18h58m}, once(playlist_rnr666)),
+    ({6w and 19h-20h58m}, once(playlist_mood_sequence)),
+    ({6w and 22h-23h28m}, once(playlist_d23)),
+    ({6w11h-6w00h}, off_air_ambient_mix),                     #ambient: Merites - Gestalt
     ({7w and 8h30m-10h28m}, once(playlist_lohuma)),                    #Sunday
     ({7w and 10h30m-11h58m}, once(playlist_bambusz)),
     ({7w and 12h-14h58m}, once(playlist_donald_kacsa_klub)),

--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -473,16 +473,16 @@ radio = switch(track_sensitive=false, transitions=[
     ({6w and 19h-20h58m}, once(playlist_mood_sequence)),
     ({6w and 22h-23h28m}, once(playlist_d23)),
     ({6w11h-6w00h}, off_air_ambient_mix),                     #ambient: Merites - Gestalt
-    ({7w and 8h30m-10h28m}, once(playlist_lohuma)),                    #Sunday
-    ({7w and 10h30m-11h58m}, once(playlist_bambusz)),
-    ({7w and 12h-14h58m}, once(playlist_donald_kacsa_klub)),
-    ({7w and 15h-15h58m}, once(playlist_geigercounterculture)),
-    ({7w and 16h-16h58m}, once(playlist_hetedik_tipusu_talalkozas)),
-    ({7w and 17h-17h58m}, once(playlist_hatterzaj)),
-    ({7w and 18h-18h58m}, once(playlist_csuszka)),
-    ({7w and 19h-19h58m}, once(playlist_sub_burek)),
-    ({7w and 20h-20h58m}, once(playlist_zeneszen)),
-    ({7w and 9h-20h30m}, off_air_ambient_mix),                        #ambient: Lohuma - Zeneszen
+    ({7w and 9h30m-11h28m}, once(playlist_lohuma)),                    #Sunday
+    ({7w and 11h30m-12h58m}, once(playlist_bambusz)),
+    ({7w and 13h-15h58m}, once(playlist_donald_kacsa_klub)),
+    ({7w and 16h-16h58m}, once(playlist_geigercounterculture)),
+    ({7w and 17h-17h58m}, once(playlist_hetedik_tipusu_talalkozas)),
+    ({7w and 18h-18h58m}, once(playlist_hatterzaj)),
+    ({7w and 19h-19h58m}, once(playlist_csuszka)),
+    ({7w and 20h-20h58m}, once(playlist_sub_burek)),
+    ({7w and 21h-21h58m}, once(playlist_zeneszen)),
+    ({7w and 10h-21h30m}, off_air_ambient_mix),                        #ambient: Lohuma - Zeneszen
     ({true}, radio) ])
 
 

--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -455,16 +455,16 @@ radio = switch(track_sensitive=false, transitions=[
     ({4w and 20h-21h58m}, once(playlist_schmerz)),
     ({4w and 22h-23h28m}, once(playlist_gyogyfurdo)),
     ({4w and 13h30m-22h30m}, off_air_ambient_mix),                        #ambient: Ritka csut - Gyogyf
-    ({5w and 10h-11h58m}, once(playlist_ritka_pentek)),                #Friday
-    ({5w and 12h00m-12h28m}, once(playlist_melania)),                     
-    ({5w and 12h30m-13h58m}, once(playlist_szusivacsi)),
-    ({5w and 14h-14h58m}, once(playlist_randomcsunyalanyok)),           
-    ({5w and 15h-15h58m}, once(playlist_dead_hound)),
-    ({5w and 16h-16h58m}, once(playlist_graveyard_slot)),
-    ({5w and 17h-17h58m}, once(playlist_brainfuq)),
-    ({5w and 18h-18h58m}, once(playlist_moneyka)),
-    ({5w and 19h-20h58m}, once(playlist_arcadeok_alatt)),       
-    ({5w and 12h15m-21h30m}, off_air_ambient_mix),                        #ambient: Ritka pentek - Rev
+    ({5w and 11h-12h58m}, once(playlist_ritka_pentek)),                #Friday
+    ({5w and 13h00m-13h28m}, once(playlist_melania)),                     
+    ({5w and 13h30m-14h58m}, once(playlist_szusivacsi)),
+    ({5w and 15h-15h58m}, once(playlist_randomcsunyalanyok)),           
+    ({5w and 16h-16h58m}, once(playlist_dead_hound)),
+    ({5w and 17h-17h58m}, once(playlist_graveyard_slot)),
+    ({5w and 18h-18h58m}, once(playlist_brainfuq)),
+    ({5w and 19h-19h58m}, once(playlist_moneyka)),
+    ({5w and 20h-21h58m}, once(playlist_arcadeok_alatt)),       
+    ({5w and 13h15m-22h30m}, off_air_ambient_mix),                        #ambient: Ritka pentek - Rev
     ({6w and 9h30m-11h28m}, once(playlist_merites)),                  #Saturday
     ({6w and 11h30m-12h28m}, once(playlist_jambikus_nesz)),     
     ({6w and 12h30m-14h58m}, once(playlist_torso)),


### PR DESCRIPTION
Please review the winter-time changes due on October 30 at 3am. My logic was: we have now CET = UTC+2 -> the clock will substract one hour -> CET=UTC+1 -> in the Liquidsoap script we'll have to add one hour (as it operates on UTC).

For easier editing and review, I commited the per-day changes separately.

~~ Revert of #469 